### PR TITLE
Change to work on other client and not english only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 TremorWatch is a World of Warcraft addon which allows you to see if enemy tremor totem exists somewhere around and delay before its next pulse
+
+updated version which works on all client
+<img width="747" height="629" alt="image" src="https://github.com/user-attachments/assets/81cfcd8d-284c-4967-a7ea-6280a4e836f5" />

--- a/TremorWatch.lua
+++ b/TremorWatch.lua
@@ -129,21 +129,18 @@ function TremorWatchMainFrame:OnTremorSet(tremorGuid)
 end
 
 local function COMBAT_LOG_EVENT_UNFILTERED(timestamp, eventType, sourceGUID, sourceName, sourceFlags, destGUID, destName, destFlags, destId)
-	if not TremorWatchSettings.DB[Keys.TestMode] then
-		local isHostile = bit.band(destFlags, COMBATLOG_OBJECT_REACTION_HOSTILE) == COMBATLOG_OBJECT_REACTION_HOSTILE
-		if not isHostile then return end
-		
-		local tremorSpellId = 8143
-		name, rank, icon, castTime, minRange, maxRange, spellId = GetSpellInfo(tremorSpellId)
-		
-		if destName == name then
-			if eventType == "UNIT_DIED" then
-				TremorWatchMainFrame:Hide()
-			elseif eventType == "SPELL_SUMMON" then
-				TremorWatchMainFrame:OnTremorSet(destGUID)
-			end
-		end	
-	end
+    if not TremorWatchSettings.DB[Keys.TestMode] then
+        local isHostile = bit.band(destFlags, COMBATLOG_OBJECT_REACTION_HOSTILE) == COMBATLOG_OBJECT_REACTION_HOSTILE
+        
+        if eventType == "SPELL_SUMMON" and destId == 8143 then
+            if not isHostile then return end
+            TremorWatchMainFrame:OnTremorSet(destGUID)
+            
+        elseif eventType == "UNIT_DIED" and TremorWatchMainFrame.GUID == destGUID then
+            TremorWatchMainFrame:Hide()
+            TremorWatchMainFrame.GUID = nil
+        end
+    end
 end
 
 local function OnMouseDown(self, button)


### PR DESCRIPTION
Using DestName was making it only available on english client. it check for the spellID only now.
Also it remove the icon if the totem is destroy to avoid a spam sound if there is no totem.